### PR TITLE
Add strict mode to allow for block-scoped declarations

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const React = require('react')
 const isNode = typeof window == 'undefined'
 


### PR DESCRIPTION
Fixing:

`index.js:52`
`let sizes = Object.keys(src)`
`^^^`
`SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode`
